### PR TITLE
Pane resizing and nested/vertical pane groups (fixes #91 and #92)

### DIFF
--- a/dist/template-app/js/resize.js
+++ b/dist/template-app/js/resize.js
@@ -1,0 +1,246 @@
+// Global drag-related variables
+var CURSOR_IN_DRAG_ZONE = false,
+    CAN_DRAG = false,
+    IS_DRAGGING = false;
+
+// Get the root .pane-group element
+var rootPaneGroup = Array.from(document.getElementsByClassName('pane-group'))[0];
+
+// Build pane tree
+buildPaneTree(rootPaneGroup);
+
+// Rebuild tree on resize
+window.onresize = function() { buildPaneTree(rootPaneGroup); }
+
+// Build pane tree recursively
+function buildPaneTree(el) {
+  // Base case
+  if (isPane(el) && !isPaneGroup(el)) {
+    return ({ node: el });
+  } else {
+    if (isPaneGroup(el)) {
+      var splitters;
+
+      // Only allow .pane elements to pass through
+      var panes = objToArr(el.childNodes).filter(function(child) {
+        if (objToArr(child.classList).includes('pane')) return true;
+        else return false;
+      });
+
+      // Append splitters to DOM then split panes equally
+      appendSplitters(el, panes, isVerticalPaneGroup(el), function() {
+        var elementDimension,
+            splitterClass;
+
+        // Set variables based on pane-group direction
+        if (isVerticalPaneGroup(el)) {
+          elementDimension = getExistingHeight(el);
+          splitterClass = 'splitter-vertical';
+        } else {
+          elementDimension = getExistingWidth(el);
+          splitterClass = 'splitter';
+        }
+
+        // Set the flex-basis for each pane
+        panes.forEach(function(pane, i) {
+          if (pane.style.flexBasis === '') {
+            setFlexBasis(pane, (elementDimension / panes.length));
+          }
+        });
+
+        // Push the splitters to an array
+        splitters = objToArr(el.childNodes).filter(function(child) {
+          if (objToArr(child.classList).includes(splitterClass)) return true;
+          else return false;
+        });
+      });
+
+      splitters.forEach(function(s, i) {
+        s.onmousedown = resizer.bind(null, i, panes, isVerticalPaneGroup(el));
+      })
+
+      return {
+        child_panes: panes.map(function(child) {
+          return buildPaneTree(child)
+        }),
+        node: el,
+        splitters: splitters,
+        vertical: isVerticalPaneGroup(el)
+      }
+    }
+  }
+}
+
+function appendSplitters(el, panes, isVertical, setSplitters) {
+  // Appends a .splitter before every pane except for first child in the group
+  panes.forEach(function(pane, i) {
+    if (isVertical) {
+      if (i !== 0 && !objToArr(pane.previousSibling.classList).includes('splitter-vertical')) {
+        var splitter = document.createElement('div'),
+            zone = document.createElement('div');
+        splitter.classList.add('splitter-vertical');
+        zone.classList.add('splitter-zone-vertical');
+        el.insertBefore(splitter, pane);
+        splitter.appendChild(zone);
+      }
+    } else {
+      if (i !== 0 && !objToArr(pane.previousSibling.classList).includes('splitter')) {
+        var splitter = document.createElement('div'),
+            zone = document.createElement('div');
+        splitter.classList.add('splitter');
+        zone.classList.add('splitter-zone');
+        el.insertBefore(splitter, pane);
+        splitter.appendChild(zone);
+      }
+    }
+  });
+  // Set each .pane's flex-basis property after splitters have
+  // been appended to the DOM
+  setSplitters();
+}
+
+function resizer(i, panes, vertical, e) {
+  CAN_DRAG = true;
+
+  function resizePanes(prev, next, prevFlex, nextFlex) {
+    setFlexBasis(prev, prevFlex);
+    setFlexBasis(next, nextFlex);
+  }
+
+  // Vertical .pane-group resizing
+  if (vertical) {
+    var initialCursorY = e.clientY,
+        topPane = panes[i],
+        bottomPane = panes[i + 1],
+        topPaneHeight = getExistingHeight(topPane),
+        bottomPaneHeight = getExistingHeight(bottomPane),
+        topPaneMaxHeight = getExistingMaxheight(topPane),
+        bottomPaneMaxHeight = getExistingMaxheight(bottomPane),
+        topPaneHasMaxHeight = !isNaN(topPaneMaxHeight),
+        bottomPaneHasMaxHeight = !isNaN(bottomPaneMaxHeight);
+
+    document.onmousemove = function (e) {
+      if (CAN_DRAG) {
+        IS_DRAGGING = true;
+        var distanceTraveledY = initialCursorY - e.clientY,
+            newTopPaneHeight = topPaneHeight - distanceTraveledY,
+            newBottomPaneHeight = bottomPaneHeight + distanceTraveledY;
+
+        // Allow resize only if new height < max height
+        if ((topPaneHasMaxHeight && !bottomPaneHasMaxHeight) &&
+            (newTopPaneHeight <= topPaneMaxHeight)) {
+          resizePanes(topPane, bottomPane, newTopPaneHeight, newBottomPaneHeight);
+        }
+        else if ((!topPaneHasMaxHeight && bottomPaneHasMaxHeight) &&
+                 (newBottomPaneHeight <= bottomPaneMaxHeight)) {
+          resizePanes(topPane, bottomPane, newTopPaneHeight, newBottomPaneHeight);
+        }
+        else if ((topPaneHasMaxHeight && bottomPaneHasMaxHeight) &&
+                (newTopPaneHeight <= topPaneMaxHeight) &&
+                (newBottomPaneHeight <= bottomPaneMaxHeight)) {
+          resizePanes(topPane, bottomPane, newTopPaneHeight, newBottomPaneHeight);
+        }
+        else if (!topPaneHasMaxHeight && !bottomPaneHasMaxHeight) {
+          resizePanes(topPane, bottomPane, newTopPaneHeight, newBottomPaneHeight);
+        }
+      }
+      document.onmouseup = function (e) {
+        IS_DRAGGING = false;
+        CAN_DRAG = false;
+      }
+    }
+  }
+  // Horizontal .pane-group resizing
+  else {
+    var initialCursorX = e.clientX,
+        leftPane = panes[i],
+        rightPane = panes[i + 1],
+        leftPaneWidth = getExistingWidth(leftPane),
+        rightPaneWidth = getExistingWidth(rightPane),
+        leftPaneMaxWidth = getExistingMaxWidth(leftPane),
+        rightPaneMaxWidth = getExistingMaxWidth(rightPane),
+        leftPaneHasMaxWidth = !isNaN(leftPaneMaxWidth),
+        rightPaneHasMaxWidth = !isNaN(rightPaneMaxWidth);
+
+    document.onmousemove = function (e) {
+      if (CAN_DRAG) {
+        IS_DRAGGING = true;
+        var distanceTraveledX = initialCursorX - e.clientX,
+            newLeftPaneWidth = leftPaneWidth - distanceTraveledX,
+            newRightPaneWidth = rightPaneWidth + distanceTraveledX;
+
+        // Allow resize only if new width < max width
+        if ((leftPaneHasMaxWidth && !rightPaneHasMaxWidth) &&
+            (newLeftPaneWidth <= leftPaneMaxWidth)) {
+          resizePanes(leftPane, rightPane, newLeftPaneWidth, newRightPaneWidth);
+        }
+        else if ((!leftPaneHasMaxWidth && rightPaneHasMaxWidth) &&
+                 (newRightPaneWidth <= rightPaneMaxWidth)) {
+          resizePanes(leftPane, rightPane, newLeftPaneWidth, newRightPaneWidth);
+        }
+        else if ((leftPaneHasMaxWidth && rightPaneHasMaxWidth) &&
+                (newLeftPaneWidth <= leftPaneMaxWidth) &&
+                (newRightPaneWidth <= rightPaneMaxWidth)) {
+          resizePanes(leftPane, rightPane, newLeftPaneWidth, newRightPaneWidth);
+        }
+        else if (!leftPaneHasMaxWidth && !rightPaneHasMaxWidth) {
+          resizePanes(leftPane, rightPane, newLeftPaneWidth, newRightPaneWidth);
+        }
+      }
+      document.onmouseup = function (e) {
+        IS_DRAGGING = false;
+        CAN_DRAG = false;
+      }
+    }
+  }
+}
+
+// Utility Functions
+// App-specific utilities
+function isPane(el) {
+  return hasClass(el, 'pane');
+}
+function isPaneGroup(el) {
+  return hasClass(el, 'pane-group');
+}
+function isVerticalPaneGroup(el) {
+  return hasClass(el, 'pane-group-vertical');
+}
+// General utilities
+function objToArr(obj) {
+  if (Array.isArray(obj)) {
+    return obj;
+  } else {
+    var arr = [];
+    for (var key in obj) {
+      arr.push(obj[key]);
+    }
+    return arr;
+  }
+}
+function hasClass(el, className) {
+  if (objToArr(el.classList).includes(className)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+// Style utilities
+function getExistingStyle(el, prop) {
+  return parseInt(document.defaultView.getComputedStyle(el)[prop], 10);
+}
+function getExistingWidth(el) {
+  return getExistingStyle(el, 'width');
+}
+function getExistingMaxWidth(el) {
+  return getExistingStyle(el, 'maxWidth');
+}
+function getExistingHeight(el) {
+  return getExistingStyle(el, 'height');
+}
+function getExistingMaxheight(el) {
+  return getExistingStyle(el, 'maxHeight');
+}
+function setFlexBasis(el, flexBasis) {
+  el.setAttribute('style', 'flex-basis: ' + flexBasis + 'px');
+}

--- a/dist/template-app/resize-demo.html
+++ b/dist/template-app/resize-demo.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Photon</title>
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="../css/photon.css">
+
+    <!-- Javascript -->
+    <script src="js/menu.js" charset="utf-8"></script>
+  </head>
+  <body>
+    <div class="window">
+
+      <!-- .toolbar-header sits at the top of your app -->
+      <header class="toolbar toolbar-header">
+        <h1 class="title">Photon</h1>
+      </header>
+
+      <!-- Your app's content goes inside .window-content -->
+      <div class="window-content">
+        <div class="pane-group">
+          <div class="pane pane-sm sidebar">
+            <nav class="nav-group">
+              <h5 class="nav-group-title">Favorites</h5>
+              <span class="nav-group-item">
+                <span class="icon icon-home"></span>
+                connors
+              </span>
+              <span class="nav-group-item active">
+                <span class="icon icon-light-up"></span>
+                Photon
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-download"></span>
+                Downloads
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-folder"></span>
+                Documents
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-window"></span>
+                Applications
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-signal"></span>
+                AirDrop
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-monitor"></span>
+                Desktop
+              </span>
+            </nav>
+          </div>
+          <div class="pane pane-group pane-group-vertical">
+            <div class="pane pane-group">
+              <div class="pane">Nest .panes and .pane-groups as deep as you want.</div>
+              <div class="pane">Nest .panes and .pane-groups as deep as you want.</div>
+              <div class="pane pane-group pane-group-vertical">
+                <div class="pane">Vertical .pane-groups</div>
+                <div class="pane">Click and drag to resize your panes.</div>
+              </div>
+            </div>
+            <div class="pane">
+              <table class="table-striped">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Kind</th>
+                    <th>Date Modified</th>
+                    <th>Author</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>bars.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>base.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>button-groups.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>buttons.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>docs.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>forms.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>grid.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>icons.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>images.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>lists.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>mixins.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>navs.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>normalize.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>photon.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>tables.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>tabs.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>utilities.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                  <tr>
+                    <td>variables.scss</td>
+                    <td>Document</td>
+                    <td>Oct 13, 2015</td>
+                    <td>connors</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="js/resize.js" charset="utf-8"></script>
+  </body>
+</html>

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -2,13 +2,34 @@
 // The Grid.css
 // --------------------------------------------------
 
-.pane-group {
+// Only the root-level .pane-group is fixed positioned
+.window-content > .pane-group {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
+}
+
+.pane-group {
   display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  flex: 1;
+}
+
+// Vertical pane groups
+.pane-group-vertical {
+  flex-direction: column;
+  justify-content: space-between;
+  // Only apply these styles to direct .pane descendents
+  > .pane {
+    border-left: 0;
+    border-top: 1px solid $border-color;
+    &:first-child {
+      border-top: 0;
+    }
+  }
 }
 
 .pane {

--- a/sass/photon.scss
+++ b/sass/photon.scss
@@ -20,5 +20,6 @@
 @import "lists.scss";
 @import "navs.scss";
 @import "icons.scss";
+@import "splitters.scss";
 @import "tables.scss";
 @import "tabs.scss";

--- a/sass/splitters.scss
+++ b/sass/splitters.scss
@@ -1,0 +1,37 @@
+//
+// Splitters.css
+// --------------------------------------------------
+$splitter-color: transparent;
+$splitter-size: 1px;
+$splitter-zone-size: 10px;
+
+// .splitter and .splitter elements are created automatically in resize.js
+
+.splitter {
+  background: $splitter-color;
+  width: $splitter-size;
+  position: relative;
+}
+.splitter-zone {
+  z-index: 1000;
+  cursor: col-resize;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: (-$splitter-zone-size / 2);
+  right: (-$splitter-zone-size / 2);
+}
+.splitter-vertical {
+  background: $splitter-color;
+  height: $splitter-size;
+  position: relative;
+}
+.splitter-zone-vertical {
+  z-index: 1000;
+  cursor: row-resize;
+  position: absolute;
+  top: (-$splitter-zone-size / 2);
+  bottom: (-$splitter-zone-size / 2);
+  left: 0;
+  right: 0;
+}


### PR DESCRIPTION
In resize.js, the buildPaneTree() method loops through the DOM
recursively and gets all the pane and pane-groups. During this process,
splitter elements are created and appended between panes and the
resizer() method is attached to each splitter onmousedown. The
resizer() method takes the initial cursor position and sets the
flex-basis of its neighboring panes based on the distance moved.

Additionally, pane-groups can be nested in one another (`<div
class="pane pane-group">`) and a new class, `.pane-group-vertical`, is
used to stack panes vertically.

None of these changes will affect anything that has already been built.